### PR TITLE
fjerner shouldDisplayFiltersOnRIght

### DIFF
--- a/force-app/main/default/flexipages/HOT_Phone_Case_Record_Page.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/HOT_Phone_Case_Record_Page.flexipage-meta.xml
@@ -73,10 +73,6 @@
                     <name>maxEARContainerHeight</name>
                     <value>500</value>
                 </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>shouldDisplayFiltersOnRight</name>
-                    <value>false</value>
-                </componentInstanceProperties>
                 <componentName>forceKnowledge:articleSearchDesktop</componentName>
                 <identifier>forceKnowledge_articleSearchDesktop</identifier>
             </componentInstance>

--- a/force-app/main/default/flexipages/HOT_STO_Case_Record_Page.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/HOT_STO_Case_Record_Page.flexipage-meta.xml
@@ -76,10 +76,6 @@
                     <name>maxEARContainerHeight</name>
                     <value>500</value>
                 </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>shouldDisplayFiltersOnRight</name>
-                    <value>true</value>
-                </componentInstanceProperties>
                 <componentName>forceKnowledge:articleSearchDesktop</componentName>
                 <identifier>forceKnowledge_articleSearchDesktop</identifier>
             </componentInstance>

--- a/force-app/main/default/flexipages/HOT_ServicetjenestenAccountRecordPage.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/HOT_ServicetjenestenAccountRecordPage.flexipage-meta.xml
@@ -295,10 +295,6 @@
                     <name>maxEARContainerHeight</name>
                     <value>500</value>
                 </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>shouldDisplayFiltersOnRight</name>
-                    <value>false</value>
-                </componentInstanceProperties>
                 <componentName>forceKnowledge:articleSearchDesktop</componentName>
                 <identifier>forceKnowledge_articleSearchDesktop</identifier>
             </componentInstance>

--- a/force-app/main/default/flexipages/HOT_ServicetjenestenKnowledgeRecordPage.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/HOT_ServicetjenestenKnowledgeRecordPage.flexipage-meta.xml
@@ -611,10 +611,6 @@
                     <name>maxEARContainerHeight</name>
                     <value>500</value>
                 </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>shouldDisplayFiltersOnRight</name>
-                    <value>true</value>
-                </componentInstanceProperties>
                 <componentName>forceKnowledge:articleSearchDesktop</componentName>
                 <identifier>forceKnowledge_articleSearchDesktop</identifier>
                 <visibilityRule>


### PR DESCRIPTION
Fjerner property som ikke brukes i SIT. 