### PR TITLE
TOLK-2656 legge til settings som fjerner filter på knowledge search

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -74,6 +74,18 @@
         },
         "liveMessageSettings": {
             "enableLiveMessage": true
+        },
+        "searchSettings": {
+            "enableEinsteinSearchEs4kPilot": false,
+            "documentContentSearchEnabled": true,
+            "optimizeSearchForCJKEnabled": false,
+            "recentlyViewedUsersForBlankLookupEnabled": true,
+            "searchSettingsByObject": {},
+            "sidebarAutoCompleteEnabled": true,
+            "sidebarDropDownListEnabled": true,
+            "sidebarLimitToItemsIOwnCheckboxEnabled": true,
+            "singleSearchResultShortcutEnabled": true,
+            "spellCorrectKnowledgeSearchEnabled": false
         }
     }
 }


### PR DESCRIPTION
Setter enableEinsteinSearchEs4kPilot til false for å unngå problemer med property som ikke brukes i SIT. 
Øvrige innstillinger er påkrevd, med verdier tatt fra eksisterende scratch-innstillinger.