### PR TITLE
TOLK-2948- Callflow fix - apex og flow

### DIFF
--- a/force-app/main/default/classes/HOT_CallFlowController.cls
+++ b/force-app/main/default/classes/HOT_CallFlowController.cls
@@ -12,58 +12,90 @@ public without sharing class HOT_CallFlowController {
     }
 
     @InvocableMethod(
-        label='Get Caller'
-        description='Use the Puzzel Session ID to collect the Caller.'
+        label='Get Caller and Call queue'
+        description='Use the Puzzel Session ID to collect the Caller, and matches the Puzzel queue name from enquiry log to determine the caller context'
         category='Call Flow'
     )
-    public static List<CallerResponse> getCallerInfo(List<String> sessionIds) {
-        List<CallerResponse> respList = new List<CallerResponse>();
+    public static List<CallInfoResponse> getCallerInfo(List<String> sessionIds) {
+        List<CallInfoResponse> results = new List<CallInfoResponse>();
 
-        if (getEnquiryLogObject() == null && !Test.isRunningTest()) {
-            for (String puzSessionId : sessionIds) {
-                respList.add(new CallerResponse('')); //Blank Phonenumber as fallback when there is no match
+        Boolean isFallback = getEnquiryLogObject() == null && !Test.isRunningTest();
+        if (isFallback) {
+            for (String sid : sessionIds) {
+                results.add(new CallInfoResponse('', 'PERSON', 'TEST QUEUE', ''));
             }
-        } else {
-            List<Object> enqLogs = getEnquiryLogs(sessionIds);
-            system.debug('Enquirylog test' + getEnquiryLogs(sessionIds));
-            for (Object enqLog : enqLogs) {
-                Map<String, Object> enqMap = (Map<String, Object>) enqLog;
-                if (enqMap.containsKey('puzzel__Caller__c'))
-                    //String caller = (String) enqMap.get('puzzel__Caller__c');
-                    respList.add(new CallerResponse((String) enqMap.get('puzzel__Caller__c')));
+            return results;
+        }
+
+        List<Object> logs = getEnquiryLogs(sessionIds);
+
+        // collect all queue names for metadata lookup
+        Set<String> queueNames = new Set<String>();
+        for (Object record : logs) {
+            Map<String, Object> recMap = (Map<String, Object>) record;
+            if (recMap.containsKey('puzzel__Queue__c')) {
+                queueNames.add((String) recMap.get('puzzel__Queue__c'));
             }
         }
-        return respList;
+
+        // load metadata
+        Map<String, Puzzel_Queue_Mapping__mdt> mappings = new Map<String, Puzzel_Queue_Mapping__mdt>();
+        for (Puzzel_Queue_Mapping__mdt md : getQueueMappings(queueNames)) {
+            mappings.put(md.Puzzel_Queue_Name__c, md);
+        }
+
+        // build response
+        for (Object record : logs) {
+            Map<String, Object> recMap = (Map<String, Object>) record;
+            String caller = recMap.containsKey('puzzel__Caller__c') ? (String) recMap.get('puzzel__Caller__c') : '';
+            String queueName = recMap.containsKey('puzzel__Queue__c') ? (String) recMap.get('puzzel__Queue__c') : '';
+            Puzzel_Queue_Mapping__mdt md = mappings.get(queueName);
+
+            String themeGroup = (md != null) ? md.Theme_Group_Code__c : 'PERSON';
+            String callerContext = (md != null) ? md.Caller_Context__c : 'TEST QUEUE';
+
+            results.add(new CallInfoResponse(caller, themeGroup, callerContext, queueName));
+        }
+
+        return results;
     }
 
-    /**
-     * @description: Queries the enquiry logs matching the sessionId set.
-     * @author Stian Ruud Schikora | 05-28-2021
-     * @param sessionIds
-     * @return List<SObject>
-     **/
     private static List<Object> getEnquiryLogs(List<String> sessionIds) {
-        fflib_QueryFactory queryFactory = new fflib_QueryFactory(getEnquiryLogObject());
+        fflib_QueryFactory qf = new fflib_QueryFactory(getEnquiryLogObject());
+        String soql = qf.selectFields(QUERY_FIELDS).setCondition('puzzel__SessionId__c IN :sessionIds').toSOQL();
 
-        return Test.isRunningTest()
-            ? (List<Object>) JSON.deserializeUntyped(HOT_CallFlowControllerTest.MOCK_ENQUIRY_LOG)
-            : (List<Object>) JSON.deserializeUntyped(
-                  JSON.serialize(
-                      Database.query(
-                          queryFactory.selectFields(QueryFields)
-                              .setCondition('puzzel__SessionId__c in :sessionIds')
-                              .toSOQL()
-                      )
-                  )
-              );
+        if (Test.isRunningTest()) {
+            return (List<Object>) JSON.deserializeUntyped(HOT_CallFlowControllerTest.MOCK_ENQUIRY_LOG);
+        }
+        return (List<Object>) JSON.deserializeUntyped(JSON.serialize(Database.query(soql)));
     }
 
-    public class CallerResponse {
-        @invocableVariable
-        public String callerNumber;
+    private static List<Puzzel_Queue_Mapping__mdt> getQueueMappings(Set<String> queueNames) {
+        if (queueNames == null || queueNames.isEmpty()) {
+            return new List<Puzzel_Queue_Mapping__mdt>();
+        }
+        return [
+            SELECT Puzzel_Queue_Name__c, Theme_Group_Code__c, Caller_Context__c
+            FROM Puzzel_Queue_Mapping__mdt
+            WHERE Puzzel_Queue_Name__c IN :queueNames
+        ];
+    }
 
-        public CallerResponse(String callerNumber) {
+    public class CallerInfoResponse {
+        @InvocableVariable
+        public String callerNumber;
+        @InvocableVariable
+        public String themeGroup;
+        @InvocableVariable
+        public String callerContext;
+        @InvocableVariable
+        public String queueName;
+
+        public CallInfoResponse(String callerNumber, String themeGroup, String callerContext, String queueName) {
             this.callerNumber = callerNumber;
+            this.themeGroup = themeGroup;
+            this.callerContext = callerContext;
+            this.queueName = queueName;
         }
     }
 }

--- a/force-app/main/default/classes/HOT_CallFlowController.cls
+++ b/force-app/main/default/classes/HOT_CallFlowController.cls
@@ -2,11 +2,6 @@ public without sharing class HOT_CallFlowController {
     private static final List<String> QUERY_FIELDS = new List<String>{ 'puzzel__SessionId__c', 'puzzel__Caller__c' };
     private static Map<String, Schema.SObjectType> globalDesc = Schema.getGlobalDescribe();
 
-    /**
-     * @description: Returns the Enquiry log SObject type if it exists
-     * @author Stian Ruud Schikora | 05-28-2021
-     * @return Schema.SObjectType
-     **/
     private static Schema.SObjectType getEnquiryLogObject() {
         return globalDesc.containsKey('puzzel__EnquiryLog__c') ? globalDesc.get('puzzel__EnquiryLog__c') : null;
     }

--- a/force-app/main/default/classes/HOT_CallFlowController.cls
+++ b/force-app/main/default/classes/HOT_CallFlowController.cls
@@ -1,5 +1,5 @@
 public without sharing class HOT_CallFlowController {
-    private static final List<String> QueryFields = new List<String>{ 'puzzel__SessionId__c', 'puzzel__Caller__c' };
+    private static final List<String> QUERY_FIELDS = new List<String>{ 'puzzel__SessionId__c', 'puzzel__Caller__c' };
     private static Map<String, Schema.SObjectType> globalDesc = Schema.getGlobalDescribe();
 
     /**
@@ -16,13 +16,13 @@ public without sharing class HOT_CallFlowController {
         description='Use the Puzzel Session ID to collect the Caller, and matches the Puzzel queue name from enquiry log to determine the caller context'
         category='Call Flow'
     )
-    public static List<CallInfoResponse> getCallerInfo(List<String> sessionIds) {
-        List<CallInfoResponse> results = new List<CallInfoResponse>();
+    public static List<CallerResponse> getCallerInfo(List<String> sessionIds) {
+        List<CallerResponse> results = new List<CallerResponse>();
 
         Boolean isFallback = getEnquiryLogObject() == null && !Test.isRunningTest();
         if (isFallback) {
             for (String sid : sessionIds) {
-                results.add(new CallInfoResponse('', 'PERSON', 'TEST QUEUE', ''));
+                results.add(new CallerResponse('', 'PERSON', 'TEST QUEUE', ''));
             }
             return results;
         }
@@ -54,7 +54,7 @@ public without sharing class HOT_CallFlowController {
             String themeGroup = (md != null) ? md.Theme_Group_Code__c : 'PERSON';
             String callerContext = (md != null) ? md.Caller_Context__c : 'TEST QUEUE';
 
-            results.add(new CallInfoResponse(caller, themeGroup, callerContext, queueName));
+            results.add(new CallerResponse(caller, themeGroup, callerContext, queueName));
         }
 
         return results;
@@ -62,7 +62,9 @@ public without sharing class HOT_CallFlowController {
 
     private static List<Object> getEnquiryLogs(List<String> sessionIds) {
         fflib_QueryFactory qf = new fflib_QueryFactory(getEnquiryLogObject());
-        String soql = qf.selectFields(QUERY_FIELDS).setCondition('puzzel__SessionId__c IN :sessionIds').toSOQL();
+        String soql = qf.selectFields(QUERY_FIELDS)
+            .setCondition('puzzel__SessionId__c IN :sessionIds')
+            .toSOQL();
 
         if (Test.isRunningTest()) {
             return (List<Object>) JSON.deserializeUntyped(HOT_CallFlowControllerTest.MOCK_ENQUIRY_LOG);
@@ -81,7 +83,7 @@ public without sharing class HOT_CallFlowController {
         ];
     }
 
-    public class CallerInfoResponse {
+    public class CallerResponse {
         @InvocableVariable
         public String callerNumber;
         @InvocableVariable
@@ -91,7 +93,7 @@ public without sharing class HOT_CallFlowController {
         @InvocableVariable
         public String queueName;
 
-        public CallInfoResponse(String callerNumber, String themeGroup, String callerContext, String queueName) {
+        public CallerResponse(String callerNumber, String themeGroup, String callerContext, String queueName) {
             this.callerNumber = callerNumber;
             this.themeGroup = themeGroup;
             this.callerContext = callerContext;

--- a/force-app/main/default/classes/HOT_CallFlowControllerTest.cls
+++ b/force-app/main/default/classes/HOT_CallFlowControllerTest.cls
@@ -1,23 +1,48 @@
 @isTest
 public class HOT_CallFlowControllerTest {
     public static final String TEST_SESSION_ID = '1234TEST';
-    public static final String TEST_CALLER = '12345678';
+    public static final String TEST_CALLER     = '12345678';
 
+    // Referenced by HOT_CallFlowController.getEnquiryLogs() when Test.isRunningTest() == true
     public static final String MOCK_ENQUIRY_LOG =
-        '[{"puzzel__SessionId__c":"' +
-        TEST_SESSION_ID +
-        '", "puzzel__Caller__c": "' +
-        TEST_CALLER +
-        '"}]';
+        '[{"puzzel__SessionId__c":"' + TEST_SESSION_ID +
+        '", "puzzel__Caller__c":"' + TEST_CALLER + '"}]';
 
     @isTest
-    static void testGetCallerInfo() {
+    static void testGetCallerInfo_WithSessionId() {
         Test.startTest();
-        List<HOT_CallFlowController.CallerResponse> resp = HOT_CallFlowController.getCallerInfo(
-            new List<String>{ TEST_SESSION_ID }
-        );
+            List<HOT_CallFlowController.CallerResponse> responses =
+                HOT_CallFlowController.getCallerInfo(
+                    new List<String>{ TEST_SESSION_ID }
+                );
         Test.stopTest();
 
-        System.assertEquals(resp[0].callerNumber, TEST_CALLER);
+        // We always get one record back from the mock
+        System.assertEquals(1, responses.size(), 'Expected exactly one response');
+
+        HOT_CallFlowController.CallerResponse resp = responses[0];
+        System.assertEquals(TEST_CALLER,     resp.callerNumber, 'Caller number should match mock');
+        System.assertEquals('PERSON',        resp.themeGroup,   'Default themeGroup');
+        System.assertEquals('TEST QUEUE',    resp.callerContext,'Default callerContext');
+        System.assertEquals('',              resp.queueName,    'queueName should be empty');
+    }
+
+    @isTest
+    static void testGetCallerInfo_EmptySessionList() {
+        Test.startTest();
+            List<HOT_CallFlowController.CallerResponse> responses =
+                HOT_CallFlowController.getCallerInfo(
+                    new List<String>()
+                );
+        Test.stopTest();
+
+        // The mock still returns one record, so size==1
+        System.assertEquals(1, responses.size(), 'Even with an empty input list, the mock returns one record');
+
+        HOT_CallFlowController.CallerResponse resp = responses[0];
+        System.assertEquals(TEST_CALLER,     resp.callerNumber, 'Caller number should match mock');
+        System.assertEquals('PERSON',        resp.themeGroup,   'Default themeGroup');
+        System.assertEquals('TEST QUEUE',    resp.callerContext,'Default callerContext');
+        System.assertEquals('',              resp.queueName,    'queueName should be empty');
     }
 }

--- a/force-app/main/screen-pop/flows/HOT_Inbound_Call.flow-meta.xml
+++ b/force-app/main/screen-pop/flows/HOT_Inbound_Call.flow-meta.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
     <actionCalls>
-        <name>Get_Caller</name>
-        <label>Get Caller</label>
+        <name>Get_Caller_info</name>
+        <label>Get Caller Info</label>
         <locationX>578</locationX>
         <locationY>134</locationY>
         <actionName>HOT_CallFlowController</actionName>
@@ -20,8 +20,20 @@
         <nameSegment>HOT_CallFlowController</nameSegment>
         <offset>0</offset>
         <outputParameters>
+            <assignToReference>CALLER_CONTEXT</assignToReference>
+            <name>callerContext</name>
+        </outputParameters>
+        <outputParameters>
             <assignToReference>PUZZEL_CALLER</assignToReference>
             <name>callerNumber</name>
+        </outputParameters>
+        <outputParameters>
+            <assignToReference>PUZZEL_QUEUE_NAME</assignToReference>
+            <name>queueName</name>
+        </outputParameters>
+        <outputParameters>
+            <assignToReference>THEME_GROUP_CODE</assignToReference>
+            <name>themeGroup</name>
         </outputParameters>
     </actionCalls>
     <actionCalls>
@@ -532,7 +544,7 @@ V2. Added Recordtype handling and enquirylog to collect Caller number and store 
         <locationX>452</locationX>
         <locationY>0</locationY>
         <connector>
-            <targetReference>Get_Caller</targetReference>
+            <targetReference>Get_Caller_info</targetReference>
         </connector>
     </start>
     <status>Active</status>


### PR DESCRIPTION
Endret apex klassen til å også ta med themeGroup, callerContext og queueName som brukes i flowen til å avgjøre hvilken vei flowen skal gå. Dette burde nå fikse problemet med at det ikke blir opprettet en case når innringer ikke oppgir personnummer.
