### PR TITLE
TOLK-3630 : Legge til enhetsnummer på bilsenter på samme måte som på hjelpemiddelsentralene

### DIFF
--- a/force-app/main/default/classes/HOT_HjelpemiddelsentralControllerTest.cls
+++ b/force-app/main/default/classes/HOT_HjelpemiddelsentralControllerTest.cls
@@ -99,7 +99,7 @@ public without sharing class HOT_HjelpemiddelsentralControllerTest {
 
         // Check against Custom Metadata existence
         if (result != null) {
-            System.assertEquals('Østlandet', result.BilsenterNavn__c, 'Expected Østlandet for Region 03');
+            System.assertEquals('Østlandet (4703)', result.BilsenterNavn__c, 'Expected Østlandet (4703) for Region 03');
         }
     }
 
@@ -122,9 +122,9 @@ public without sharing class HOT_HjelpemiddelsentralControllerTest {
 
         if (result != null) {
             System.assertEquals(
-                'Østlandet',
+                'Østlandet (4703)',
                 result.BilsenterNavn__c,
-                'Should return Bilsenter navn Østlandet for fylkenummer: 34 og kommunenummer: 3401'
+                'Should return Bilsenter navn Østlandet (4703) for fylkenummer: 34 og kommunenummer: 3401'
             );
         }
     }
@@ -186,9 +186,9 @@ public without sharing class HOT_HjelpemiddelsentralControllerTest {
         Test.stopTest();
 
         System.assertEquals(
-            'Vest-Norge',
+            'Vest-Norge (4712)',
             result.BilsenterNavn__c,
-            'Should return null when region is missing and municipality is too short'
+            'Should return Bilsenter navn Vest-Norge (4712) when region is derived from municipality'
         );
     }
 
@@ -269,9 +269,9 @@ public without sharing class HOT_HjelpemiddelsentralControllerTest {
 
         if (result != null) {
             System.assertEquals(
-                'Østlandet',
+                'Østlandet (4703)',
                 result.BilsenterNavn__c,
-                'Should return Bilsenter navn Østlandet for fylkenummer: 34 og kommunenummer: 3401'
+                'Should return Bilsenter navn Østlandet (4703) for fylkenummer: 34 og kommunenummer: 3401'
             );
         }
     }

--- a/force-app/main/default/customMetadata/HOT_BilsenterMapping.Agder.md-meta.xml
+++ b/force-app/main/default/customMetadata/HOT_BilsenterMapping.Agder.md-meta.xml
@@ -4,7 +4,7 @@
     <protected>false</protected>
     <values>
         <field>BilsenterNavn__c</field>
-        <value xsi:type="xsd:string">Sør-Norge</value>
+        <value xsi:type="xsd:string">Sørvest-Norge (4711)</value>
     </values>
     <values>
         <field>BilsenterUrl__c</field>

--- a/force-app/main/default/customMetadata/HOT_BilsenterMapping.Akershus.md-meta.xml
+++ b/force-app/main/default/customMetadata/HOT_BilsenterMapping.Akershus.md-meta.xml
@@ -4,7 +4,7 @@
     <protected>false</protected>
     <values>
         <field>BilsenterNavn__c</field>
-        <value xsi:type="xsd:string">Østlandet</value>
+        <value xsi:type="xsd:string">Østlandet (4703)</value>
     </values>
     <values>
         <field>BilsenterUrl__c</field>

--- a/force-app/main/default/customMetadata/HOT_BilsenterMapping.Buskerud.md-meta.xml
+++ b/force-app/main/default/customMetadata/HOT_BilsenterMapping.Buskerud.md-meta.xml
@@ -4,7 +4,7 @@
     <protected>false</protected>
     <values>
         <field>BilsenterNavn__c</field>
-        <value xsi:type="xsd:string">Østlandet</value>
+        <value xsi:type="xsd:string">Østlandet (4703)</value>
     </values>
     <values>
         <field>BilsenterUrl__c</field>

--- a/force-app/main/default/customMetadata/HOT_BilsenterMapping.Finnmark.md-meta.xml
+++ b/force-app/main/default/customMetadata/HOT_BilsenterMapping.Finnmark.md-meta.xml
@@ -4,7 +4,7 @@
     <protected>false</protected>
     <values>
         <field>BilsenterNavn__c</field>
-        <value xsi:type="xsd:string">Nord-Norge</value>
+        <value xsi:type="xsd:string">Nord-Norge (4719)</value>
     </values>
     <values>
         <field>BilsenterUrl__c</field>

--- a/force-app/main/default/customMetadata/HOT_BilsenterMapping.Innlandet_Midt_Norge.md-meta.xml
+++ b/force-app/main/default/customMetadata/HOT_BilsenterMapping.Innlandet_Midt_Norge.md-meta.xml
@@ -4,7 +4,7 @@
     <protected>false</protected>
     <values>
         <field>BilsenterNavn__c</field>
-        <value xsi:type="xsd:string">Midt-Norge</value>
+        <value xsi:type="xsd:string">Midt-Norge (4716)</value>
     </values>
     <values>
         <field>BilsenterUrl__c</field>

--- a/force-app/main/default/customMetadata/HOT_BilsenterMapping.Innlandet_ostlandet.md-meta.xml
+++ b/force-app/main/default/customMetadata/HOT_BilsenterMapping.Innlandet_ostlandet.md-meta.xml
@@ -4,7 +4,7 @@
     <protected>false</protected>
     <values>
         <field>BilsenterNavn__c</field>
-        <value xsi:type="xsd:string">Østlandet</value>
+        <value xsi:type="xsd:string">Østlandet (4703)</value>
     </values>
     <values>
         <field>BilsenterUrl__c</field>

--- a/force-app/main/default/customMetadata/HOT_BilsenterMapping.More_og_Romsdal.md-meta.xml
+++ b/force-app/main/default/customMetadata/HOT_BilsenterMapping.More_og_Romsdal.md-meta.xml
@@ -4,7 +4,7 @@
     <protected>false</protected>
     <values>
         <field>BilsenterNavn__c</field>
-        <value xsi:type="xsd:string">Midt-Norge</value>
+        <value xsi:type="xsd:string">Midt-Norge (4716)</value>
     </values>
     <values>
         <field>BilsenterUrl__c</field>

--- a/force-app/main/default/customMetadata/HOT_BilsenterMapping.Nordland.md-meta.xml
+++ b/force-app/main/default/customMetadata/HOT_BilsenterMapping.Nordland.md-meta.xml
@@ -4,7 +4,7 @@
     <protected>false</protected>
     <values>
         <field>BilsenterNavn__c</field>
-        <value xsi:type="xsd:string">Midt-Norge</value>
+        <value xsi:type="xsd:string">Midt-Norge (4716)</value>
     </values>
     <values>
         <field>BilsenterUrl__c</field>

--- a/force-app/main/default/customMetadata/HOT_BilsenterMapping.Nordland_Nord_Norge.md-meta.xml
+++ b/force-app/main/default/customMetadata/HOT_BilsenterMapping.Nordland_Nord_Norge.md-meta.xml
@@ -4,7 +4,7 @@
     <protected>false</protected>
     <values>
         <field>BilsenterNavn__c</field>
-        <value xsi:type="xsd:string">Nord-Norge</value>
+        <value xsi:type="xsd:string">Nord-Norge (4719)</value>
     </values>
     <values>
         <field>BilsenterUrl__c</field>

--- a/force-app/main/default/customMetadata/HOT_BilsenterMapping.Oslo.md-meta.xml
+++ b/force-app/main/default/customMetadata/HOT_BilsenterMapping.Oslo.md-meta.xml
@@ -4,7 +4,7 @@
     <protected>false</protected>
     <values>
         <field>BilsenterNavn__c</field>
-        <value xsi:type="xsd:string">Østlandet</value>
+        <value xsi:type="xsd:string">Østlandet (4703)</value>
     </values>
     <values>
         <field>BilsenterUrl__c</field>

--- a/force-app/main/default/customMetadata/HOT_BilsenterMapping.Ostfold.md-meta.xml
+++ b/force-app/main/default/customMetadata/HOT_BilsenterMapping.Ostfold.md-meta.xml
@@ -4,7 +4,7 @@
     <protected>false</protected>
     <values>
         <field>BilsenterNavn__c</field>
-        <value xsi:type="xsd:string">Østlandet</value>
+        <value xsi:type="xsd:string">Østlandet (4703)</value>
     </values>
     <values>
         <field>BilsenterUrl__c</field>

--- a/force-app/main/default/customMetadata/HOT_BilsenterMapping.Rogaland.md-meta.xml
+++ b/force-app/main/default/customMetadata/HOT_BilsenterMapping.Rogaland.md-meta.xml
@@ -4,7 +4,7 @@
     <protected>false</protected>
     <values>
         <field>BilsenterNavn__c</field>
-        <value xsi:type="xsd:string">Sørvest-Norge</value>
+        <value xsi:type="xsd:string">Sørvest-Norge (4711)</value>
     </values>
     <values>
         <field>BilsenterUrl__c</field>

--- a/force-app/main/default/customMetadata/HOT_BilsenterMapping.Telemark.md-meta.xml
+++ b/force-app/main/default/customMetadata/HOT_BilsenterMapping.Telemark.md-meta.xml
@@ -4,7 +4,7 @@
     <protected>false</protected>
     <values>
         <field>BilsenterNavn__c</field>
-        <value xsi:type="xsd:string">Østlandet</value>
+        <value xsi:type="xsd:string">Østlandet (4703)</value>
     </values>
     <values>
         <field>BilsenterUrl__c</field>

--- a/force-app/main/default/customMetadata/HOT_BilsenterMapping.Tromso.md-meta.xml
+++ b/force-app/main/default/customMetadata/HOT_BilsenterMapping.Tromso.md-meta.xml
@@ -4,7 +4,7 @@
     <protected>false</protected>
     <values>
         <field>BilsenterNavn__c</field>
-        <value xsi:type="xsd:string">Nord-Norge</value>
+        <value xsi:type="xsd:string">Nord-Norge (4719)</value>
     </values>
     <values>
         <field>BilsenterUrl__c</field>

--- a/force-app/main/default/customMetadata/HOT_BilsenterMapping.Trondelag.md-meta.xml
+++ b/force-app/main/default/customMetadata/HOT_BilsenterMapping.Trondelag.md-meta.xml
@@ -4,7 +4,7 @@
     <protected>false</protected>
     <values>
         <field>BilsenterNavn__c</field>
-        <value xsi:type="xsd:string">Midt-Norge</value>
+        <value xsi:type="xsd:string">Midt-Norge (4716)</value>
     </values>
     <values>
         <field>BilsenterUrl__c</field>

--- a/force-app/main/default/customMetadata/HOT_BilsenterMapping.Vestfold.md-meta.xml
+++ b/force-app/main/default/customMetadata/HOT_BilsenterMapping.Vestfold.md-meta.xml
@@ -4,7 +4,7 @@
     <protected>false</protected>
     <values>
         <field>BilsenterNavn__c</field>
-        <value xsi:type="xsd:string">Østlandet</value>
+        <value xsi:type="xsd:string">Østlandet (4703)</value>
     </values>
     <values>
         <field>BilsenterUrl__c</field>

--- a/force-app/main/default/customMetadata/HOT_BilsenterMapping.Vestlande.md-meta.xml
+++ b/force-app/main/default/customMetadata/HOT_BilsenterMapping.Vestlande.md-meta.xml
@@ -4,7 +4,7 @@
     <protected>false</protected>
     <values>
         <field>BilsenterNavn__c</field>
-        <value xsi:type="xsd:string">Vest-Norge</value>
+        <value xsi:type="xsd:string">Vest-Norge (4712)</value>
     </values>
     <values>
         <field>BilsenterUrl__c</field>

--- a/force-app/main/default/lwc/hot_hjelpemiddelsentral/hot_hjelpemiddelsentral.html
+++ b/force-app/main/default/lwc/hot_hjelpemiddelsentral/hot_hjelpemiddelsentral.html
@@ -68,20 +68,20 @@
         </h3>
         <div aria-hidden={ariaHidden} class="slds-section__content" id="expando-unique-id2">
             <div class="slds-var-p-horizontal_medium" lwc:if={bilsenterString}>
-                <lightning-formatted-text value="Tilhører " class="slds-text-title text"></lightning-formatted-text>
+                <lightning-formatted-text
+                    value="Tilhører bilsenter "
+                    class="slds-text-title text"
+                ></lightning-formatted-text>
                 <lightning-formatted-url
                     value={bilsenterUrl}
                     label={bilsenterString}
                     target="_blank"
                 ></lightning-formatted-url>
-                <lightning-formatted-text value=" bilsenter." class="slds-text-title text"></lightning-formatted-text>
+                <lightning-formatted-text value="." class="slds-text-title text"></lightning-formatted-text>
             </div>
         </div>
         <div class="slds-var-p-horizontal_medium" lwc:if={bilsenterError}>
-            <lightning-formatted-text
-                value={bilsenterError}
-                class="slds-text-title text"
-            ></lightning-formatted-text>
+            <lightning-formatted-text value={bilsenterError} class="slds-text-title text"></lightning-formatted-text>
         </div>
     </div>
 </template>


### PR DESCRIPTION
- Fikset Agder mapping til å være Sørvest-Norge
- La til enhetsnummer og endret på ordlyden
- Fikset tester